### PR TITLE
Add sanity check before sending notifyViewControllerWillAppearAnimated: message

### DIFF
--- a/motcha/UI/Navigation/UIViewController+Swizzling.m
+++ b/motcha/UI/Navigation/UIViewController+Swizzling.m
@@ -32,8 +32,9 @@
 #pragma mark - Method Swizzling
 - (void)override_viewWillAppear:(BOOL)animated {
   [self override_viewWillAppear:animated];
-  NSLog(@"override viewWillAppear: %@", self);
   MCNavigationController *navigationControler = (MCNavigationController*)self.navigationController;
-  [navigationControler notifyViewControllerWillAppearAnimated:animated];
+  if ([navigationControler respondsToSelector:@selector(notifyViewControllerWillAppearAnimated:)]) {
+    [navigationControler notifyViewControllerWillAppearAnimated:animated];
+  }
 }
 @end

--- a/motcha/UI/Navigation/UIViewController+Swizzling.m
+++ b/motcha/UI/Navigation/UIViewController+Swizzling.m
@@ -35,8 +35,8 @@
   if ([self.navigationController respondsToSelector:selector]) {
     // we use NSInvocation instead of performSelector:withObject: because we need to pass a primitive type BOOL
     // instead of an object, and we do not want to modify the target implementation just because of this.
-    NSMethodSignature* signature = [[self.navigationController class] instanceMethodSignatureForSelector:selector];
-    NSInvocation* invocation = [NSInvocation invocationWithMethodSignature: signature];
+    NSMethodSignature *signature = [[self.navigationController class] instanceMethodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     [invocation setTarget:self.navigationController];
     [invocation setSelector:@selector( notifyViewControllerWillAppearAnimated:)];
     [invocation setArgument:&animated atIndex:2];

--- a/motcha/UI/Navigation/UIViewController+Swizzling.m
+++ b/motcha/UI/Navigation/UIViewController+Swizzling.m
@@ -31,8 +31,16 @@
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
 - (void)override_viewWillAppear:(BOOL)animated {
   [self override_viewWillAppear:animated];
-  if ([self.navigationController respondsToSelector:@selector(notifyViewControllerWillAppearAnimated:)]) {
-    [self.navigationController performSelector:@selector(notifyViewControllerWillAppearAnimated:)];
+  SEL selector = @selector(notifyViewControllerWillAppearAnimated:);
+  if ([self.navigationController respondsToSelector:selector]) {
+    // we use NSInvocation instead of performSelector:withObject: because we need to pass a primitive type BOOL
+    // instead of an object, and we do not want to modify the target implementation just because of this.
+    NSMethodSignature* signature = [[self.navigationController class] instanceMethodSignatureForSelector:selector];
+    NSInvocation* invocation = [NSInvocation invocationWithMethodSignature: signature];
+    [invocation setTarget:self.navigationController];
+    [invocation setSelector:@selector( notifyViewControllerWillAppearAnimated:)];
+    [invocation setArgument:&animated atIndex:2];
+    [invocation invoke];
   }
 }
 @end

--- a/motcha/UI/Navigation/UIViewController+Swizzling.m
+++ b/motcha/UI/Navigation/UIViewController+Swizzling.m
@@ -2,8 +2,6 @@
 
 #import <objc/runtime.h>
 
-#import "MCNavigationController.h"
-
 @implementation UIViewController (Swizzling)
 + (void)load {
   static dispatch_once_t onceToken;
@@ -30,11 +28,11 @@
 }
 
 #pragma mark - Method Swizzling
+#pragma GCC diagnostic ignored "-Wundeclared-selector"
 - (void)override_viewWillAppear:(BOOL)animated {
   [self override_viewWillAppear:animated];
-  MCNavigationController *navigationControler = (MCNavigationController*)self.navigationController;
-  if ([navigationControler respondsToSelector:@selector(notifyViewControllerWillAppearAnimated:)]) {
-    [navigationControler notifyViewControllerWillAppearAnimated:animated];
+  if ([self.navigationController respondsToSelector:@selector(notifyViewControllerWillAppearAnimated:)]) {
+    [self.navigationController performSelector:@selector(notifyViewControllerWillAppearAnimated:)];
   }
 }
 @end


### PR DESCRIPTION
For safety concerns, added sanity check to guarantee that this message is responded by the receiver.